### PR TITLE
fix autoloading issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,11 @@
     },
     "autoload": {
         "psr-4": {
-            "WP_Queue\\": "src\\WP_Queue"
-        }
+            "WP_Queue\\": "WP_Queue"
+        },
+        "files": [
+          "wp-queue.php"
+        ]
     },
     "require-dev": {
         "stevegrunwell/wp-enforcer": "^0.5.0"


### PR DESCRIPTION
Hi! Thanks for working on wp-queue! We use your plugin as a composer dependency (in another plugin). As you moved the folder `src/WP_Queue` to it's parent directory (see [the original repo](https://github.com/deliciousbrains/wp-queue/tree/master/src)), the psr-4 autoloader path also has to be updated.
Autoloading the wp-queue.php makes the global functions (like `wp_queue`)also available.
